### PR TITLE
Fix lockup and crash when no Epic Box server responds

### DIFF
--- a/lib/services/coins/epiccash/epiccash_wallet.dart
+++ b/lib/services/coins/epiccash/epiccash_wallet.dart
@@ -1109,7 +1109,7 @@ class EpicCashWallet extends CoinServiceAPI {
       Logging.instance.log("Default Epic Box server not connected",
           level: LogLevel.Warning);
 
-      // Copy list of all default EB servers but remove currently-connected one
+      // Copy list of all default EB servers but remove currently-selected one
       List<EpicBoxModel> alternativeServers = DefaultEpicBoxes.all;
       alternativeServers.removeWhere((opt) => opt.name == _epicBox?.name);
 

--- a/lib/services/coins/epiccash/epiccash_wallet.dart
+++ b/lib/services/coins/epiccash/epiccash_wallet.dart
@@ -1105,26 +1105,30 @@ class EpicCashWallet extends CoinServiceAPI {
         await testEpicboxServer(_epicBox.host, _epicBox.port as int);
 
     if (!connected) {
-      //Default Epic Box is not connected, iterate through list of defaults
-      Logging.instance.log("Default Epic Box server not connected",
-          level: LogLevel.Warning);
+      print("DEFAULT EPIC BOX IS NOT CONNECTED");
 
-      // Copy list of all default EB servers but remove currently-connected one
-      List<EpicBoxModel> alternativeServers = DefaultEpicBoxes.all;
-      alternativeServers.removeWhere((opt) => opt.name == _epicBox?.name);
+      //Get all available hosts
+      final allBoxes = DefaultEpicBoxes.all;
+      final List<EpicBoxModel> alternativeServers = [];
 
-      // Try each alternative Epic Box server
-      bool altConnected = false;
-      for (EpicBoxModel alt in alternativeServers) {
-        altConnected = await testEpicboxServer(alt.host, alt.port as int);
-        if (altConnected == true) {
-          _epicBox = alt;
-          break;
+      for (var i = 0; i < allBoxes.length; i++) {
+        if (allBoxes[i].name != _epicBox?.name) {
+          alternativeServers.add(allBoxes[i]);
         }
       }
-      if (!altConnected) {
-        Logging.instance
-            .log("No Epic Box server connected!", level: LogLevel.Error);
+
+      bool altConnected = false;
+      int i = 1;
+      while (i < alternativeServers.length) {
+        while (altConnected == false) {
+          altConnected = await testEpicboxServer(
+              alternativeServers[i].host, alternativeServers[i].port as int);
+          if (altConnected == true) {
+            _epicBox = alternativeServers[i];
+            break;
+          }
+        }
+        i++;
       }
     }
 

--- a/lib/services/coins/epiccash/epiccash_wallet.dart
+++ b/lib/services/coins/epiccash/epiccash_wallet.dart
@@ -1105,30 +1105,26 @@ class EpicCashWallet extends CoinServiceAPI {
         await testEpicboxServer(_epicBox.host, _epicBox.port as int);
 
     if (!connected) {
-      print("DEFAULT EPIC BOX IS NOT CONNECTED");
+      //Default Epic Box is not connected, iterate through list of defaults
+      Logging.instance.log("Default Epic Box server not connected",
+          level: LogLevel.Warning);
 
-      //Get all available hosts
-      final allBoxes = DefaultEpicBoxes.all;
-      final List<EpicBoxModel> alternativeServers = [];
+      // Copy list of all default EB servers but remove currently-connected one
+      List<EpicBoxModel> alternativeServers = DefaultEpicBoxes.all;
+      alternativeServers.removeWhere((opt) => opt.name == _epicBox?.name);
 
-      for (var i = 0; i < allBoxes.length; i++) {
-        if (allBoxes[i].name != _epicBox?.name) {
-          alternativeServers.add(allBoxes[i]);
+      // Try each alternative Epic Box server
+      bool altConnected = false;
+      for (EpicBoxModel alt in alternativeServers) {
+        altConnected = await testEpicboxServer(alt.host, alt.port as int);
+        if (altConnected == true) {
+          _epicBox = alt;
+          break;
         }
       }
-
-      bool altConnected = false;
-      int i = 1;
-      while (i < alternativeServers.length) {
-        while (altConnected == false) {
-          altConnected = await testEpicboxServer(
-              alternativeServers[i].host, alternativeServers[i].port as int);
-          if (altConnected == true) {
-            _epicBox = alternativeServers[i];
-            break;
-          }
-        }
-        i++;
+      if (!altConnected) {
+        Logging.instance
+            .log("No Epic Box server connected!", level: LogLevel.Error);
       }
     }
 

--- a/lib/services/coins/epiccash/epiccash_wallet.dart
+++ b/lib/services/coins/epiccash/epiccash_wallet.dart
@@ -1127,6 +1127,9 @@ class EpicCashWallet extends CoinServiceAPI {
               alternativeServers[i].host, alternativeServers[i].port as int);
           if (altConnected == true) {
             _epicBox = alternativeServers[i];
+            Logging.instance.log(
+                "Connected to alternate Epic Box server ${json.encode(_epicBox)}",
+                level: LogLevel.Info);
             break;
           }
         }

--- a/lib/services/coins/epiccash/epiccash_wallet.dart
+++ b/lib/services/coins/epiccash/epiccash_wallet.dart
@@ -1109,7 +1109,7 @@ class EpicCashWallet extends CoinServiceAPI {
       Logging.instance.log("Default Epic Box server not connected",
           level: LogLevel.Warning);
 
-      // Copy list of all default EB servers but remove currently-selected one
+      // Copy list of all default EB servers but remove currently-connected one
       List<EpicBoxModel> alternativeServers = DefaultEpicBoxes.all;
       alternativeServers.removeWhere((opt) => opt.name == _epicBox?.name);
 

--- a/lib/services/coins/epiccash/epiccash_wallet.dart
+++ b/lib/services/coins/epiccash/epiccash_wallet.dart
@@ -1085,7 +1085,10 @@ class EpicCashWallet extends CoinServiceAPI {
     return stringConfig;
   }
 
-  Future<String> getEpicBoxConfig({EpicBoxModel? epicBox}) async {
+  Future<String> getEpicBoxConfig({EpicBoxModel? epicBox, int? tries}) async {
+    if ((tries ?? 0) > DefaultEpicBoxes.all.length) {
+      throw Exception("No Epic Box servers responded");
+    }
     EpicBoxModel? _epicBox = epicBox ??
         DB.instance.get<EpicBoxModel>(
             boxName: DB.boxNamePrimaryEpicBox, key: 'primary');
@@ -1116,7 +1119,9 @@ class EpicCashWallet extends CoinServiceAPI {
         _epicBox = DefaultEpicBoxes.europe;
       }
       return getEpicBoxConfig(
-          epicBox: _epicBox); // recursively try again until we are connected
+          epicBox: _epicBox,
+          tries:
+              tries ?? 0 + 1); // recursively try again until we are connected
     }
 
     Map<String, dynamic> _config = {

--- a/lib/services/coins/epiccash/epiccash_wallet.dart
+++ b/lib/services/coins/epiccash/epiccash_wallet.dart
@@ -1105,7 +1105,9 @@ class EpicCashWallet extends CoinServiceAPI {
         await testEpicboxServer(_epicBox.host, _epicBox.port as int);
 
     if (!connected) {
-      print("DEFAULT EPIC BOX IS NOT CONNECTED");
+      //Default Epic Box is not connected, iterate through list of defaults
+      Logging.instance.log("Default Epic Box server not connected",
+          level: LogLevel.Warning);
 
       //Get all available hosts
       final allBoxes = DefaultEpicBoxes.all;
@@ -1129,6 +1131,10 @@ class EpicCashWallet extends CoinServiceAPI {
           }
         }
         i++;
+      }
+      if (!altConnected) {
+        Logging.instance
+            .log("No Epic Box server connected!", level: LogLevel.Error);
       }
     }
 


### PR DESCRIPTION
If no Epic Box server is available the app can lockup and eventually crash if no Epic Box server responds.  This fixes that by only trying each node once