### PR TITLE
Fix Epic Box server host/domain on receive view and do not initalizeExisting() on server change, just update address and listenForSlates()

### DIFF
--- a/lib/pages/settings_views/epicbox_settings_view/sub_widgets/epicbox_card.dart
+++ b/lib/pages/settings_views/epicbox_settings_view/sub_widgets/epicbox_card.dart
@@ -126,7 +126,10 @@ class _EpicBoxCardState extends ConsumerState<EpicBoxCard> {
                     .setPrimaryEpicBox(
                       epicBox: _epicBox,
                     );
-                await ref.read(walletProvider)!.initializeExisting();
+
+                await (ref.read(walletProvider)!).updateEpicBox();
+                // await ref.read(walletProvider)!.initializeExisting();
+                // await ref.read(walletProvider)!.generateNewAddress();
 
                 if (mounted) {
                   Navigator.of(context).pop();
@@ -307,10 +310,13 @@ class _EpicBoxMenuState extends ConsumerState<EpicBoxMenu> {
                                   epicBox: widget.epicBox,
                                 );
 
-                            await ref
-                                .read(walletProvider)!
-                                .initializeExisting();
-                            // await ref.read(walletProvider)!.updateEpicBox(true);
+                            await ref.read(walletProvider)!.updateEpicBox();
+                            // await ref
+                            //     .read(walletProvider)!
+                            //     .initializeExisting();
+                            // await ref
+                            //     .read(walletProvider)!
+                            //     .generateNewAddress();
 
                             if (mounted) {
                               Navigator.of(context).pop();
@@ -411,12 +417,15 @@ class _EpicBoxMenuState extends ConsumerState<EpicBoxMenu> {
                                     .setPrimaryEpicBox(
                                       epicBox: widget.epicBox,
                                     );
+
+                                await ref.read(walletProvider)!.updateEpicBox();
                                 // await ref
                                 //     .read(walletProvider)!
-                                //     .updateEpicBox(true);
-                                await ref
-                                    .read(walletProvider)!
-                                    .initializeExisting();
+                                //     .initializeExisting();
+                                // await ref
+                                //     .read(walletProvider)!
+                                //     .generateNewAddress();
+
                                 if (mounted) {
                                   Navigator.of(context).pop();
                                 }

--- a/lib/services/coins/epiccash/epiccash_wallet.dart
+++ b/lib/services/coins/epiccash/epiccash_wallet.dart
@@ -1179,6 +1179,18 @@ class EpicCashWallet extends CoinServiceAPI {
     return jsonEncode(_config);
   }
 
+  // Used to update receiving address when updating epic box config
+  // Because we don't generate a new address for epic but we do change the
+  // address based on the epicbox host/domain/URL we must force an update here
+  Future<bool> updateEpicBox() async {
+    try {
+      _currentReceivingAddress = _getCurrentAddressForChain(0);
+      return true;
+    } catch (e, s) {
+      return false;
+    }
+  }
+
   Future<String> getRealConfig() async {
     String? config = await _secureStore.read(key: '${_walletId}_config');
     if (Platform.isIOS) {

--- a/lib/services/coins/epiccash/epiccash_wallet.dart
+++ b/lib/services/coins/epiccash/epiccash_wallet.dart
@@ -1187,6 +1187,8 @@ class EpicCashWallet extends CoinServiceAPI {
       _currentReceivingAddress = _getCurrentAddressForChain(0);
       return true;
     } catch (e, s) {
+      Logging.instance.log("$e, $s", level: LogLevel.Error);
+      throw Exception("Error in updateEpicBox (_getCurrentAddressForChain)");
       return false;
     }
   }

--- a/lib/services/coins/manager.dart
+++ b/lib/services/coins/manager.dart
@@ -294,11 +294,13 @@ class Manager with ChangeNotifier {
         notifyListeners();
       } else {
         throw Exception(
-            'Error updating Epic Box server (getCurrentReceivingAddress and/or listenForSlates');
+            'Error in updateEpicBox updating Epic Box server (updateEpicBox ie. getCurrentReceivingAddress)');
       }
       return success;
     } catch (e, s) {
       Logging.instance.log("$e, $s", level: LogLevel.Error);
+      throw Exception(
+          'Error in updateEpicBox updating Epic Box server (updateEpicBox ie. getCurrentReceivingAddress and/or listenForSlates');
       return false;
     }
   }

--- a/lib/services/coins/manager.dart
+++ b/lib/services/coins/manager.dart
@@ -285,13 +285,21 @@ class Manager with ChangeNotifier {
   Future<bool> updateEpicBox() async {
     // Update address for receive page update
     // generateNewAddress();
-    final success = await (_currentWallet as EpicCashWallet).updateEpicBox();
-    await (_currentWallet as EpicCashWallet)
-        .listenForSlates(); // TODO try-catch this
-    // TODO close old listeners, if there are any.
-    if (success) {
-      notifyListeners();
+    try {
+      final success = await (_currentWallet as EpicCashWallet).updateEpicBox();
+      await (_currentWallet as EpicCashWallet)
+          .listenForSlates(); // TODO try-catch this
+      // TODO close old listeners, if there are any.
+      if (success) {
+        notifyListeners();
+      } else {
+        throw Exception(
+            'Error updating Epic Box server (getCurrentReceivingAddress and/or listenForSlates');
+      }
+      return success;
+    } catch (e, s) {
+      Logging.instance.log("$e, $s", level: LogLevel.Error);
+      return false;
     }
-    return success;
   }
 }

--- a/lib/services/coins/manager.dart
+++ b/lib/services/coins/manager.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:decimal/decimal.dart';
 import 'package:epicpay/models/models.dart';
 import 'package:epicpay/services/coins/coin_service.dart';
+import 'package:epicpay/services/coins/epiccash/epiccash_wallet.dart';
 import 'package:epicpay/services/event_bus/events/global/node_connection_status_changed_event.dart';
 import 'package:epicpay/services/event_bus/events/global/updated_in_background_event.dart';
 import 'package:epicpay/services/event_bus/global_event_bus.dart';
@@ -275,6 +276,19 @@ class Manager with ChangeNotifier {
 
   Future<bool> generateNewAddress() async {
     final success = await _currentWallet.generateNewAddress();
+    if (success) {
+      notifyListeners();
+    }
+    return success;
+  }
+
+  Future<bool> updateEpicBox() async {
+    // Update address for receive page update
+    // generateNewAddress();
+    final success = await (_currentWallet as EpicCashWallet).updateEpicBox();
+    await (_currentWallet as EpicCashWallet)
+        .listenForSlates(); // TODO try-catch this
+    // TODO close old listeners, if there are any.
     if (success) {
       notifyListeners();
     }


### PR DESCRIPTION
Instead of calling initializeExisting() and re-initializing an existing Epic Cash wallet (with the refresh() and all over related init-related methods) we just call `_getCurrentAddressForChain(0)` (to update the address and notify address listeners/watchers and then listenForSlates() directly to start listening to the new Epic Box