### PR TITLE
Fix old configs causing cast issues and correct typo

### DIFF
--- a/lib/models/epicbox_config_model.dart
+++ b/lib/models/epicbox_config_model.dart
@@ -86,9 +86,9 @@ class EpicBoxConfigModel {
     if (oldPort != "empty") {
       _epicBox['epicbox_port'] = _epicBox['port'];
     }
-    final oldProtocolInsecure = _epicBox["protocol_insecur"] ?? "empty";
+    final oldProtocolInsecure = _epicBox["protocol_insecure"] ?? "empty";
     if (oldProtocolInsecure != "empty") {
-      _epicBox['epicbox_protocol_insecure'] = _epicBox['protocol_insecur'];
+      _epicBox['epicbox_protocol_insecure'] = _epicBox['protocol_insecure'];
     }
     final oldAddressIndex = _epicBox["address_index"] ?? "empty";
     if (oldAddressIndex != "empty") {

--- a/lib/models/epicbox_config_model.dart
+++ b/lib/models/epicbox_config_model.dart
@@ -95,6 +95,9 @@ class EpicBoxConfigModel {
       _epicBox['epicbox_address_index'] = _epicBox['address_index'];
     }
 
+    _epicBox['epicbox_protocol_insecure'] ??= false;
+    _epicBox['epicbox_address_index'] ??= 0;
+
     return EpicBoxConfigModel(
       host: _epicBox['epicbox_domain'] as String,
       port: _epicBox['epicbox_port'] as int,


### PR DESCRIPTION
The typo is irrelevant but fixing it is good for future work

Null values in old configs could cause casting issues which would cascade to cause more errors like not being able to send or view your address